### PR TITLE
fix: 🐛 stream build.sh logs to stdout in nodejs

### DIFF
--- a/lambda_builders/nodejs.js
+++ b/lambda_builders/nodejs.js
@@ -100,7 +100,7 @@ async function createZip(event) {
   console.log("Running build script");
   fs.chmodSync("./build.sh", "755");
   execSync("ls -alh");
-  execSync("./build.sh", { env: env });
+  execSync("./build.sh", { env: env, stdio: "inherit" });
 
   const builtPath = "/tmp/built.zip";
   console.log(`Creating ${builtPath} from ${buildPath}`);


### PR DESCRIPTION
Helps with debugging for lambda timeouts, as exec will buffer output by
default, and a timeout will kill the process before the buffer is output
to stdout/stderr