### PR TITLE
Externalised compiler_output_dir to collect/manage build artifacts externally

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "external" "validate" {
     s3_object_version = var.s3_object_version != null ? var.s3_object_version : ""
     source_code_hash  = var.source_code_hash != null ? var.source_code_hash : ""
     source_dir        = var.source_dir
-    zip_files_dir     = "${path.module}/zip_files"
+    zip_files_dir     = var.compile_output_dir != null ? var.compile_output_dir : "${path.module}/zip_files"
   }
 }
 
@@ -41,7 +41,7 @@ module "source_zip_file" {
   enabled = var.enabled && var.build_mode != "DISABLED"
 
   empty_dirs  = var.empty_dirs
-  output_path = var.enabled && var.build_mode == "FILENAME" ? var.filename : var.enabled && var.build_mode != "DISABLED" ? "${path.module}/zip_files/${data.aws_partition.current[0].partition}-${data.aws_region.current[0].name}-${data.aws_caller_identity.current[0].account_id}-${var.function_name}.zip" : ""
+  output_path = var.enabled && var.build_mode == "FILENAME" ? var.filename : var.enabled && var.build_mode != "DISABLED" ? "${local.compile_output_dir}/${data.aws_partition.current[0].partition}-${data.aws_region.current[0].name}-${data.aws_caller_identity.current[0].account_id}-${var.function_name}.zip" : ""
   source_dir  = var.source_dir
 }
 
@@ -72,6 +72,7 @@ locals {
 ###############################################
 
 locals {
+  compile_output_dir     = var.compile_output_dir != null ? var.compile_output_dir : "${path.module}/zip_files"
   cloudformation_parameters = {
     Bucket    = var.s3_bucket
     KeyPrefix = var.function_name

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,12 @@ variable "filename" {
   default     = null
 }
 
+variable "compile_output_dir" {
+  description = "The path to the compilation output directory where all zip files and compiled resources will be stored."
+  type        = string
+  default     = null
+}
+
 variable "function_name" {
   description = "A unique name for your Lambda Function."
   type        = string


### PR DESCRIPTION
In regards with this issue: https://github.com/raymondbutcher/terraform-aws-lambda-builder/issues/11

Added compile_output_dir to support LAMBDA build types in CI with separated plan/apply phases