### PR TITLE
Add Node.js 14 support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,7 @@ locals {
   lambda_builder_filenames = {
     "nodejs10.x" = "nodejs.js"
     "nodejs12.x" = "nodejs.js"
+    "nodejs14.x" = "nodejs.js"
     "python2.7"  = "python.py"
     "python3.6"  = "python.py"
     "python3.7"  = "python.py"


### PR DESCRIPTION
Node 10 is EOL already, there's no breaking changes in terms of this pipeline.